### PR TITLE
Fix test failure on node v9 and later.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: node_js
 node_js:
+  - '10'
+  - '9'
   - '8'
   - '7'
   - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - 'stable'
+  - '8'
+  - '7'
+  - '6'
+  - '5'
   - '4'
   - '0.12'
   - '0.10'
-before_install:
-  - 'npm install -g npm' # get latest npm for scoped modules

--- a/index.js
+++ b/index.js
@@ -2,17 +2,18 @@
 
 var ogWrite = process.stdout.write;
 
+var muteStdout = { mute: mute, unmute: noop };
+
 function noop(){}
 
 function mute(){
+  muteStdout.unmute = unmute;
   process.stdout.write = noop;
 }
 
 function unmute(){
   process.stdout.write = ogWrite;
+  muteStdout.unmute = noop;
 }
 
-module.exports = {
-  mute: mute,
-  unmute: unmute
-};
+module.exports = muteStdout;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "lint": "eslint *.js test/*.js",
     "pretest": "npm run lint",
-    "test": "lab -cv --ignore Reflect,SharedArrayBuffer,Atomics,WebAssembly"
+    "test": "lab -cv --ignore Reflect,SharedArrayBuffer,Atomics,WebAssembly,URL,URLSearchParams,BigUint64Array,BigInt64Array,BigInt"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "lint": "eslint *.js test/*.js",
     "pretest": "npm run lint",
-    "test": "lab -cv"
+    "test": "lab -cv --ignore Reflect,SharedArrayBuffer,Atomics,WebAssembly"
   },
   "dependencies": {},
   "devDependencies": {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": 0 
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,61 +1,24 @@
 'use strict';
 
-var stream = require('stream');
-
 var lab = exports.lab = require('lab').script();
 var code = require('code');
 
 var stdout = require('../');
 
-lab.describe('mute', function(){
+lab.describe('mute-stdout', function(){
 
-  var ogWrite = stream.Duplex.prototype.write;
+  var ogWrite = process.stdout.write;
 
-  lab.it('mutes the stream', function(done){
-
-    var writes = 0;
-
-    stream.Duplex.prototype.write = function(){
-      writes++;
-    };
+  lab.it('mute and unmute ', function(done){
+    code.expect(process.stdout.write).to.equal(ogWrite);
 
     stdout.mute();
-
-    console.log('should not print');
-
-    stdout.unmute();
-    stream.Duplex.prototype.write = ogWrite;
-
-    code.expect(writes).to.equal(0);
-
-    done();
-  });
-});
-
-lab.describe('unmute', function(){
-
-  var ogWrite = stream.Duplex.prototype.write;
-
-  lab.it('unmutes a muted stream', function(done){
-
-    var writes = 0;
-
-    stream.Duplex.prototype.write = function(){
-      writes++;
-    };
-
-    stdout.mute();
-
-    console.log('should not print');
-
+    var mutedWrite = process.stdout.write;
     stdout.unmute();
 
-    console.log('should print');
-
-    stream.Duplex.prototype.write = ogWrite;
-
-    code.expect(writes).to.equal(1);
-
+    code.expect(mutedWrite).to.not.equal(ogWrite);
+    code.expect(mutedWrite.toString()).to.equal('function noop(){}');
+    code.expect(process.stdout.write).to.equal(ogWrite);
     done();
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -58,4 +58,22 @@ lab.describe('unmute', function(){
 
     done();
   });
+
+  lab.it('don\'t replace back when be not muted', function(done) {
+    var ogWrite = process.stdout.write;
+    var counter = 0;
+    process.stdout.write = function() {
+      counter++;
+    };
+
+    console.log('should count up!');
+
+    stdout.unmute();
+
+    console.log('should count up!');
+
+    process.stdout.write = ogWrite;
+    code.expect(counter).to.equal(2);
+    done();
+  });
 });


### PR DESCRIPTION
This pr is to fix the issue that the test fails on node v9 and later.

The cause of the test failure is that the implementation of `process.stdout.write` was changed from v9 as the outputs below.
The test uses `stream.Duplex.prototype.write` but node v9 doesn't use this function in `process.stdout.write`.

I changed the test to check if `process.stdout.write` equals the original write function before mute.

(This pr is based on the commit of pr #5.)

```
$ node -v
v8.11.1
$ node
> process.stdout.write.toString()
'function (chunk, encoding, cb) {                                               
  if (typeof chunk !== \'string\' && !(chunk instanceof Buffer)) {
    throw new TypeError(
      \'Invalid data, chunk must be a string or buffer, not \' + typeof chunk);
  }
  return stream.Duplex.prototype.write.apply(this, arguments);
}'
```
```
$ node -v
v9.11.1
$ node
> process.stdout.write.toString()
'function (chunk, encoding, cb) {                                               
  var state = this._writableState;
  var ret = false;
  var isBuf = !state.objectMode && Stream._isUint8Array(chunk);

  if (isBuf && Object.getPrototypeOf(chunk) !== Buffer.prototype) {
    chunk = Stream._uint8ArrayToBuffer(chunk);
  }

  if (typeof encoding === \'function\') {
    cb = encoding;
    encoding = null;
  }

  if (isBuf)
    encoding = \'buffer\';
  else if (!encoding)
    encoding = state.defaultEncoding;

  if (typeof cb !== \'function\')
    cb = nop;

  if (state.ending)
    writeAfterEnd(this, cb);
  else if (isBuf || validChunk(this, state, chunk, cb)) {
    state.pendingcb++;
    ret = writeOrBuffer(this, state, isBuf, chunk, encoding, cb);
  }

  return ret;
}'
```
